### PR TITLE
Install gems locally

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "gems"


### PR DESCRIPTION
I believe most laypeople won't be using ruby env managers, and will then told
they don't have write permissions (for the global system ruby files). This
should install and use the gems locally.